### PR TITLE
will no longer cut off data in first column

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function parse(output, options) {
           for (var key in limits) {
               var header = limits[key];
               var nextKey = parseInt(key, 10)+1;
-              var start = header.start;
+              var start = (key === 0) ? 0 : header.start;
               var end = (limits[nextKey]) ? limits[nextKey].start - header.start : undefined;
 
               result[header.label] = line.substr(start, end).trim();

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function parse(output, options) {
           for (var key in limits) {
               var header = limits[key];
               var nextKey = parseInt(key, 10)+1;
-              var start = (key === 0) ? 0 : header.start;
+              var start = (key === '0') ? 0 : header.start;
               var end = (limits[nextKey]) ? limits[nextKey].start - header.start : undefined;
 
               result[header.label] = line.substr(start, end).trim();

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function parse(output, options) {
               var header = limits[key];
               var nextKey = parseInt(key, 10)+1;
               var start = (key === '0') ? 0 : header.start;
-              var end = (limits[nextKey]) ? limits[nextKey].start - header.start : undefined;
+              var end = (limits[nextKey]) ? limits[nextKey].start - start : undefined;
 
               result[header.label] = line.substr(start, end).trim();
           }

--- a/index.js
+++ b/index.js
@@ -39,7 +39,6 @@ module.exports = function parse(output, options) {
       }
   });
 
-  console.log('table: ', table);
   (table[table.length-1] === undefined) && table.pop();
 
   return table;


### PR DESCRIPTION
In my test case, I have data in the first column that looks like this:

```
  pid
  352
  165
13845
24524
```

Before my contribution, it would truncate "13845" to "845", and "24524" to "524".
I'm getting the table from the default ps in OSX 10.10.2.
